### PR TITLE
fix: adjust shields.io image path for build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/@lti-tool/core"><img alt="npm" src="https://img.shields.io/npm/dm/%40lti-tool%2Fcore?style=flat-square" /></a>
-  <a href="https://github.com/lti-tool/lti-tool/actions/workflows/ci.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/lti-tool/lti-tool/ci.yml?style=flat-square&branch=dev" /></a>
+  <a href="https://github.com/lti-tool/lti-tool/actions/workflows/ci.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/lti-tool/lti-tool/release.yml" /></a>
 </p>
 
 ## Why This Library?


### PR DESCRIPTION
Adjust the path to the shields.io build status so it renders properly