### PR TITLE
Ags extension lineitem results

### DIFF
--- a/.changeset/ags-extension-fields.md
+++ b/.changeset/ags-extension-fields.md
@@ -1,0 +1,5 @@
+---
+'@lti-tool/core': patch
+---
+
+Preserve AGS platform extension fields and allow callers to read specific line item results and details.

--- a/.changeset/ags-extension-fields.md
+++ b/.changeset/ags-extension-fields.md
@@ -2,4 +2,4 @@
 '@lti-tool/core': patch
 ---
 
-Preserve AGS platform extension fields and allow callers to read specific line item results and details.
+Preserve AGS platform extension fields, support standard result filters and schema fields, and allow callers to read specific line item results and details.

--- a/packages/core/src/ltiTool.ts
+++ b/packages/core/src/ltiTool.ts
@@ -35,6 +35,7 @@ import {
 } from './schemas/lti13/nrps/contextMembership.schema.js';
 import {
   AGSService,
+  type AGSGetScoresOptions,
   type AGSLineItemTargetOptions,
   type AGSListLineItemsOptions,
 } from './services/ags.service.js';
@@ -368,7 +369,7 @@ export class LTITool {
    * Retrieves all scores for a specific line item from the platform using Assignment and Grade Services (AGS).
    *
    * @param session - Active LTI session containing AGS service endpoints
-   * @param options - Optional AGS line item list filters
+   * @param options - Optional line item target override and AGS result filters
    * @returns Array of score submissions for the line item
    * @throws {Error} When AGS is not available or request fails
    *
@@ -380,7 +381,7 @@ export class LTITool {
    */
   async getScores(
     session: LTISession,
-    options: AGSLineItemTargetOptions = {},
+    options: AGSGetScoresOptions = {},
   ): Promise<Results> {
     if (!session) {
       throw new Error('session is required');
@@ -401,7 +402,7 @@ export class LTITool {
    * Retrieves line items (gradebook columns) from the platform using Assignment and Grade Services (AGS).
    *
    * @param session - Active LTI session containing AGS service endpoints
-   * @param options - Optional line item target override
+   * @param options - Optional AGS line item list filters
    * @returns Array of line items from the platform
    * @throws {Error} When AGS is not available or request fails
    */

--- a/packages/core/src/ltiTool.ts
+++ b/packages/core/src/ltiTool.ts
@@ -344,7 +344,6 @@ export class LTITool {
    * Submits a grade score to the platform using Assignment and Grade Services (AGS).
    *
    * @param session - Active LTI session containing AGS service endpoints
-   * @param options - Optional line item target override
    * @param score - Score submission data including grade value and user ID
    * @throws {Error} When AGS is not available or submission fails
    */

--- a/packages/core/src/ltiTool.ts
+++ b/packages/core/src/ltiTool.ts
@@ -33,7 +33,11 @@ import {
   type Member,
   NRPSContextMembershipResponseSchema,
 } from './schemas/lti13/nrps/contextMembership.schema.js';
-import { AGSService } from './services/ags.service.js';
+import {
+  AGSService,
+  type AGSLineItemTargetOptions,
+  type AGSListLineItemsOptions,
+} from './services/ags.service.js';
 import { DeepLinkingService } from './services/deepLinking.service.js';
 import { DynamicRegistrationService } from './services/dynamicRegistration.service.js';
 import { NRPSService } from './services/nrps.service.js';
@@ -339,6 +343,7 @@ export class LTITool {
    * Submits a grade score to the platform using Assignment and Grade Services (AGS).
    *
    * @param session - Active LTI session containing AGS service endpoints
+   * @param options - Optional line item target override
    * @param score - Score submission data including grade value and user ID
    * @throws {Error} When AGS is not available or submission fails
    */
@@ -363,6 +368,7 @@ export class LTITool {
    * Retrieves all scores for a specific line item from the platform using Assignment and Grade Services (AGS).
    *
    * @param session - Active LTI session containing AGS service endpoints
+   * @param options - Optional AGS line item list filters
    * @returns Array of score submissions for the line item
    * @throws {Error} When AGS is not available or request fails
    *
@@ -372,13 +378,16 @@ export class LTITool {
    * console.log('All scores:', scores.map(s => `${s.userId}: ${s.scoreGiven}`));
    * ```
    */
-  async getScores(session: LTISession): Promise<Results> {
+  async getScores(
+    session: LTISession,
+    options: AGSLineItemTargetOptions = {},
+  ): Promise<Results> {
     if (!session) {
       throw new Error('session is required');
     }
 
     try {
-      const response = await this.agsService.getScores(session);
+      const response = await this.agsService.getScores(session, options);
       const data = await response.json();
       return ResultsSchema.parse(data);
     } catch (error) {
@@ -392,16 +401,20 @@ export class LTITool {
    * Retrieves line items (gradebook columns) from the platform using Assignment and Grade Services (AGS).
    *
    * @param session - Active LTI session containing AGS service endpoints
+   * @param options - Optional line item target override
    * @returns Array of line items from the platform
    * @throws {Error} When AGS is not available or request fails
    */
-  async listLineItems(session: LTISession): Promise<LineItems> {
+  async listLineItems(
+    session: LTISession,
+    options: AGSListLineItemsOptions = {},
+  ): Promise<LineItems> {
     if (!session) {
       throw new Error('session is required');
     }
 
     try {
-      const response = await this.agsService.listLineItems(session);
+      const response = await this.agsService.listLineItems(session, options);
       const data = await response.json();
       return LineItemsSchema.parse(data);
     } catch (error) {
@@ -418,13 +431,16 @@ export class LTITool {
    * @returns Line item data from the platform
    * @throws {Error} When AGS is not available or request fails
    */
-  async getLineItem(session: LTISession): Promise<LineItem> {
+  async getLineItem(
+    session: LTISession,
+    options: AGSLineItemTargetOptions = {},
+  ): Promise<LineItem> {
     if (!session) {
       throw new Error('session is required');
     }
 
     try {
-      const response = await this.agsService.getLineItem(session);
+      const response = await this.agsService.getLineItem(session, options);
       const data = await response.json();
       return LineItemSchema.parse(data);
     } catch (error) {

--- a/packages/core/src/schemas/lti13/ags/lineItem.schema.ts
+++ b/packages/core/src/schemas/lti13/ags/lineItem.schema.ts
@@ -30,6 +30,9 @@ export const LineItemSchema = z.looseObject({
 
   /** Optional end date/time for the assignment */
   endDateTime: z.iso.datetime().optional(),
+
+  /** Whether grades should be released to learners. */
+  gradesReleased: z.boolean().optional(),
 });
 
 /**

--- a/packages/core/src/schemas/lti13/ags/lineItem.schema.ts
+++ b/packages/core/src/schemas/lti13/ags/lineItem.schema.ts
@@ -6,7 +6,7 @@ import * as z from 'zod';
  *
  * @see https://www.imsglobal.org/spec/lti-ags/v2p0/#line-item-service
  */
-export const LineItemSchema = z.object({
+export const LineItemSchema = z.looseObject({
   /** Unique identifier for the line item */
   id: z.url(),
 

--- a/packages/core/src/schemas/lti13/ags/result.schema.ts
+++ b/packages/core/src/schemas/lti13/ags/result.schema.ts
@@ -10,20 +10,23 @@ export const ResultSchema = z.looseObject({
   /** Unique identifier for the result */
   id: z.string(),
 
-  /** Score of the result, represented as a URL */
+  /** URL identifying the line item to which this result belongs. */
   scoreOf: z.url(),
 
-  /** URL identifying the Line Item to which this result belongs. */
+  /** LTI user ID identifying the recipient of the result. */
   userId: z.string(),
 
   /** The score given to the user */
-  resultScore: z.number().optional(),
+  resultScore: z.number().nullable().optional(),
 
   /** Maximum possible score */
   resultMaximum: z.number().optional(),
 
+  /** LTI user ID identifying the provider of the result, usually an instructor. */
+  scoringUserId: z.string().optional(),
+
   /** Comment associated with the result */
-  comment: z.string().optional(),
+  comment: z.string().nullable().optional(),
 
   /** Timestamp when the result was recorded */
   timestamp: z.iso.datetime({ offset: true }).optional(),

--- a/packages/core/src/schemas/lti13/ags/result.schema.ts
+++ b/packages/core/src/schemas/lti13/ags/result.schema.ts
@@ -6,7 +6,7 @@ import * as z from 'zod';
  *
  * @see https://www.imsglobal.org/spec/lti-ags/v2p0/#result-service
  */
-export const ResultSchema = z.object({
+export const ResultSchema = z.looseObject({
   /** Unique identifier for the result */
   id: z.string(),
 

--- a/packages/core/src/services/ags.service.ts
+++ b/packages/core/src/services/ags.service.ts
@@ -12,6 +12,22 @@ import { ltiServiceFetch } from '../utils/ltiServiceFetch.js';
 
 import type { TokenService } from './token.service.js';
 
+export interface AGSLineItemTargetOptions {
+  /** Optional line item URL to read instead of the launch session's default line item. */
+  lineItemUrl?: string;
+}
+
+export interface AGSListLineItemsOptions {
+  /** Optional AGS resource_id filter. */
+  resourceId?: string;
+  /** Optional AGS resource_link_id filter. */
+  resourceLinkId?: string;
+  /** Optional AGS tag filter. */
+  tag?: string;
+  /** Optional maximum number of line items to request. */
+  limit?: number;
+}
+
 /**
  * Assignment and Grade Services (AGS) implementation for LTI 1.3.
  * Provides methods to submit grades and scores back to the platform.
@@ -89,6 +105,7 @@ export class AGSService {
    * Retrieves all scores for a specific line item from the platform using Assignment and Grade Services.
    *
    * @param session - Active LTI session containing AGS line item endpoint configuration
+   * @param options - Optional line item target override
    * @returns Promise resolving to the HTTP response containing scores data for the line item
    * @throws {Error} When AGS line item service is not available for the session or request fails
    *
@@ -99,8 +116,13 @@ export class AGSService {
    * console.log('All scores for this line item:', scores);
    * ```
    */
-  async getScores(session: LTISession): Promise<Response> {
-    if (!session.services?.ags?.lineitem) {
+  async getScores(
+    session: LTISession,
+    options: AGSLineItemTargetOptions = {},
+  ): Promise<Response> {
+    const lineItemUrl = options.lineItemUrl ?? session.services?.ags?.lineitem;
+
+    if (!lineItemUrl) {
       throw new Error('AGS line item not available for this session');
     }
 
@@ -109,7 +131,7 @@ export class AGSService {
       'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly',
     );
 
-    const resultsEndpoint = `${session.services.ags.lineitem}/results`;
+    const resultsEndpoint = `${lineItemUrl}/results`;
 
     const response = await ltiServiceFetch(resultsEndpoint, {
       method: 'GET',
@@ -127,6 +149,7 @@ export class AGSService {
    * Retrieves line items (gradebook columns) from the platform using Assignment and Grade Services.
    *
    * @param session - Active LTI session containing AGS line items endpoint configuration
+   * @param options - Optional AGS line item list filters
    * @returns Promise resolving to the HTTP response containing line items data
    * @throws {Error} When AGS line items service is not available for the session or request fails
    *
@@ -137,7 +160,10 @@ export class AGSService {
    * console.log('Available gradebook columns:', lineItems);
    * ```
    */
-  async listLineItems(session: LTISession): Promise<Response> {
+  async listLineItems(
+    session: LTISession,
+    options: AGSListLineItemsOptions = {},
+  ): Promise<Response> {
     if (!session.services?.ags?.lineitems) {
       throw new Error('AGS list line items not available for this session');
     }
@@ -147,13 +173,16 @@ export class AGSService {
       'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly',
     );
 
-    const response = await ltiServiceFetch(`${session.services.ags.lineitems}`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: 'application/vnd.ims.lis.v2.lineitemcontainer+json',
+    const response = await ltiServiceFetch(
+      this.buildLineItemsUrl(session.services.ags.lineitems, options),
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.ims.lis.v2.lineitemcontainer+json',
+        },
       },
-    });
+    );
 
     await this.validateAGSResponse(response, 'list line items');
     return response;
@@ -163,6 +192,7 @@ export class AGSService {
    * Retrieves a specific line item (gradebook column) from the platform using Assignment and Grade Services.
    *
    * @param session - Active LTI session containing AGS line item endpoint configuration
+   * @param options - Optional line item target override
    * @returns Promise resolving to the HTTP response containing the line item data
    * @throws {Error} When AGS line item service is not available for the session or request fails
    *
@@ -173,8 +203,13 @@ export class AGSService {
    * console.log('Line item details:', lineItem);
    * ```
    */
-  async getLineItem(session: LTISession): Promise<Response> {
-    if (!session.services?.ags?.lineitem) {
+  async getLineItem(
+    session: LTISession,
+    options: AGSLineItemTargetOptions = {},
+  ): Promise<Response> {
+    const lineItemUrl = options.lineItemUrl ?? session.services?.ags?.lineitem;
+
+    if (!lineItemUrl) {
       throw new Error('AGS line item not available for this session');
     }
 
@@ -183,7 +218,7 @@ export class AGSService {
       'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly',
     );
 
-    const response = await ltiServiceFetch(`${session.services.ags.lineitem}`, {
+    const response = await ltiServiceFetch(lineItemUrl, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -332,6 +367,28 @@ export class AGSService {
       launchConfig.tokenUrl,
       scope,
     );
+  }
+
+  private buildLineItemsUrl(
+    lineItemsUrl: string,
+    options: AGSListLineItemsOptions,
+  ): string {
+    const url = new URL(lineItemsUrl);
+
+    if (options.resourceId !== undefined) {
+      url.searchParams.set('resource_id', options.resourceId);
+    }
+    if (options.resourceLinkId !== undefined) {
+      url.searchParams.set('resource_link_id', options.resourceLinkId);
+    }
+    if (options.tag !== undefined) {
+      url.searchParams.set('tag', options.tag);
+    }
+    if (options.limit !== undefined) {
+      url.searchParams.set('limit', String(options.limit));
+    }
+
+    return url.toString();
   }
 
   private async validateAGSResponse(

--- a/packages/core/src/services/ags.service.ts
+++ b/packages/core/src/services/ags.service.ts
@@ -17,6 +17,13 @@ export interface AGSLineItemTargetOptions {
   lineItemUrl?: string;
 }
 
+export interface AGSGetScoresOptions extends AGSLineItemTargetOptions {
+  /** Optional AGS user_id filter for fetching a single user's result. */
+  userId?: string;
+  /** Optional maximum number of results to request. */
+  limit?: number;
+}
+
 export interface AGSListLineItemsOptions {
   /** Optional AGS resource_id filter. */
   resourceId?: string;
@@ -105,7 +112,7 @@ export class AGSService {
    * Retrieves all scores for a specific line item from the platform using Assignment and Grade Services.
    *
    * @param session - Active LTI session containing AGS line item endpoint configuration
-   * @param options - Optional line item target override
+   * @param options - Optional line item target override and AGS result filters
    * @returns Promise resolving to the HTTP response containing scores data for the line item
    * @throws {Error} When AGS line item service is not available for the session or request fails
    *
@@ -118,7 +125,7 @@ export class AGSService {
    */
   async getScores(
     session: LTISession,
-    options: AGSLineItemTargetOptions = {},
+    options: AGSGetScoresOptions = {},
   ): Promise<Response> {
     const lineItemUrl = options.lineItemUrl ?? session.services?.ags?.lineitem;
 
@@ -131,9 +138,7 @@ export class AGSService {
       'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly',
     );
 
-    const resultsEndpoint = `${lineItemUrl}/results`;
-
-    const response = await ltiServiceFetch(resultsEndpoint, {
+    const response = await ltiServiceFetch(this.buildResultsUrl(lineItemUrl, options), {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -383,6 +388,20 @@ export class AGSService {
     }
     if (options.tag !== undefined) {
       url.searchParams.set('tag', options.tag);
+    }
+    if (options.limit !== undefined) {
+      url.searchParams.set('limit', String(options.limit));
+    }
+
+    return url.toString();
+  }
+
+  private buildResultsUrl(lineItemUrl: string, options: AGSGetScoresOptions): string {
+    const url = new URL(lineItemUrl);
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/results`;
+
+    if (options.userId !== undefined) {
+      url.searchParams.set('user_id', options.userId);
     }
     if (options.limit !== undefined) {
       url.searchParams.set('limit', String(options.limit));

--- a/packages/core/test/ags.service.test.ts
+++ b/packages/core/test/ags.service.test.ts
@@ -218,4 +218,117 @@ describe('AGSService', () => {
       );
     });
   });
+
+  describe('getScores', () => {
+    beforeEach(() => {
+      mockGetValidLaunchConfig.mockResolvedValue(mockLaunchConfig);
+      mockTokenService.getBearerToken.mockResolvedValue('mock-bearer-token');
+    });
+
+    it('retrieves results from the session line item by default', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await agsService.getScores(mockSession);
+
+      expect(result).toBe(mockResponse);
+      expect(mockTokenService.getBearerToken).toHaveBeenCalledWith(
+        'client123',
+        'https://platform.example.com/token',
+        'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly',
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://platform.example.com/api/ags/lineitem/123/results',
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
+
+    it('retrieves results from a caller-provided line item URL', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await agsService.getScores(mockSession, {
+        lineItemUrl: 'https://platform.example.com/api/ags/lineitems/456',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://platform.example.com/api/ags/lineitems/456/results',
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
+  });
+
+  describe('listLineItems', () => {
+    beforeEach(() => {
+      mockGetValidLaunchConfig.mockResolvedValue(mockLaunchConfig);
+      mockTokenService.getBearerToken.mockResolvedValue('mock-bearer-token');
+    });
+
+    it('lists line items with optional AGS filters', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await agsService.listLineItems(mockSession, {
+        resourceId: 'resource-1',
+        resourceLinkId: 'resource-link-1',
+        tag: 'badges',
+        limit: 50,
+      });
+
+      expect(mockTokenService.getBearerToken).toHaveBeenCalledWith(
+        'client123',
+        'https://platform.example.com/token',
+        'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly',
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://platform.example.com/api/ags/lineitems?resource_id=resource-1&resource_link_id=resource-link-1&tag=badges&limit=50',
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
+  });
+
+  describe('getLineItem', () => {
+    beforeEach(() => {
+      mockGetValidLaunchConfig.mockResolvedValue(mockLaunchConfig);
+      mockTokenService.getBearerToken.mockResolvedValue('mock-bearer-token');
+    });
+
+    it('retrieves a caller-provided line item URL', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await agsService.getLineItem(mockSession, {
+        lineItemUrl: 'https://platform.example.com/api/ags/lineitems/456',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://platform.example.com/api/ags/lineitems/456',
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
+  });
 });

--- a/packages/core/test/ags.service.test.ts
+++ b/packages/core/test/ags.service.test.ts
@@ -268,6 +268,28 @@ describe('AGSService', () => {
         }),
       );
     });
+
+    it('retrieves filtered results while preserving line item URL query parameters', async () => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+      };
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await agsService.getScores(mockSession, {
+        lineItemUrl: 'https://platform.example.com/api/ags/lineitems/456?existing=1',
+        userId: 'learner-1',
+        limit: 25,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://platform.example.com/api/ags/lineitems/456/results?existing=1&user_id=learner-1&limit=25',
+        expect.objectContaining({
+          method: 'GET',
+        }),
+      );
+    });
   });
 
   describe('listLineItems', () => {

--- a/packages/core/test/schemas.test.ts
+++ b/packages/core/test/schemas.test.ts
@@ -65,6 +65,32 @@ describe('Schema Validation Tests', () => {
   });
 
   describe('AGS extension fields', () => {
+    it('accepts standard AGS line item fields added by platforms', () => {
+      const parsed = LineItemSchema.parse({
+        id: 'https://platform.example.com/ags/lineitems/123',
+        scoreMaximum: 100,
+        label: 'Midterm',
+        gradesReleased: true,
+      });
+
+      expect(parsed.gradesReleased).toBe(true);
+    });
+
+    it('accepts standard AGS result fields and empty result values', () => {
+      const parsed = ResultSchema.parse({
+        id: 'result-1',
+        scoreOf: 'https://platform.example.com/ags/lineitems/123',
+        userId: 'learner-1',
+        resultScore: null,
+        scoringUserId: 'instructor-1',
+        comment: null,
+      });
+
+      expect(parsed.resultScore).toBeNull();
+      expect(parsed.scoringUserId).toBe('instructor-1');
+      expect(parsed.comment).toBeNull();
+    });
+
     it('preserves platform-specific line item extension properties', () => {
       const sakaiReadOnlyProperty = 'https://www.sakailms.org/spec/lti-ags/v2p0/readOnly';
 

--- a/packages/core/test/schemas.test.ts
+++ b/packages/core/test/schemas.test.ts
@@ -9,6 +9,8 @@ import {
   SessionIdSchema,
   VerifyLaunchParamsSchema,
 } from '../src/schemas/index.js';
+import { LineItemSchema } from '../src/schemas/lti13/ags/lineItem.schema.js';
+import { ResultSchema } from '../src/schemas/lti13/ags/result.schema.js';
 import { ScoreSubmissionSchema } from '../src/schemas/lti13/ags/scoreSubmission.schema.js';
 import { NRPSContextMembershipResponseSchema } from '../src/schemas/lti13/nrps/contextMembership.schema.js';
 
@@ -59,6 +61,36 @@ describe('Schema Validation Tests', () => {
       };
 
       expect(() => LTI13LoginSchema.parse(incompleteLogin)).toThrow();
+    });
+  });
+
+  describe('AGS extension fields', () => {
+    it('preserves platform-specific line item extension properties', () => {
+      const sakaiReadOnlyProperty = 'https://www.sakailms.org/spec/lti-ags/v2p0/readOnly';
+
+      const parsed = LineItemSchema.parse({
+        id: 'https://platform.example.com/ags/lineitems/123',
+        scoreMaximum: 100,
+        label: 'Midterm',
+        [sakaiReadOnlyProperty]: true,
+      });
+
+      expect(parsed[sakaiReadOnlyProperty]).toBe(true);
+    });
+
+    it('preserves platform-specific result extension properties', () => {
+      const platformExtensionProperty =
+        'https://platform.example.com/spec/lti-ags/resultStatus';
+
+      const parsed = ResultSchema.parse({
+        id: 'result-1',
+        scoreOf: 'https://platform.example.com/ags/lineitems/123',
+        userId: 'learner-1',
+        resultScore: 95,
+        [platformExtensionProperty]: 'released',
+      });
+
+      expect(parsed[platformExtensionProperty]).toBe('released');
     });
   });
 


### PR DESCRIPTION
This PR makes AGS a little more flexible for real LMS gradebooks by preserving pltform extension fields. Let callers fetch results for a specific line item returned by `listLineItems()`, instead of only the launch-associated line item.

I kept it platform-neutral, so Sakai/Canvas-specific fields pass through to the application without `lti-tool` needing to know what they mean.