### PR TITLE
fix(core): accept array LTI launch audiences

### DIFF
--- a/.changeset/lti-aud-array.md
+++ b/.changeset/lti-aud-array.md
@@ -1,0 +1,9 @@
+---
+'@lti-tool/core': patch
+---
+
+Accept LTI 1.3 launch ID tokens whose `aud` claim is an array containing the
+tool client ID, and reject additional audiences unless configured as trusted.
+Launch verification now binds the client configuration from signed state before
+checking the ID token, and session creation preserves the verified client ID for
+multi-audience launches.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,6 +45,10 @@ const payload = await ltiTool.verifyLaunch(idToken, state);
 const session = await ltiTool.createSession(payload);
 ```
 
+When creating a session from a payload not returned directly by `verifyLaunch` on
+the same `LTITool` instance, pass the verified client ID as the second argument
+if the launch ID token contains multiple audiences.
+
 ## Documentation
 
 - [API Reference](https://docs.lti-tool.dev) - Complete API documentation

--- a/packages/core/src/interfaces/ltiConfig.ts
+++ b/packages/core/src/interfaces/ltiConfig.ts
@@ -71,6 +71,11 @@ export interface LTIConfig {
     stateExpirationSeconds?: number;
     /** Nonce expiration time in seconds (defaults to 600 = 10 minutes) */
     nonceExpirationSeconds?: number;
+    /**
+     * Additional JWT audience values to trust when a launch ID Token includes
+     * audiences besides this tool's client ID. Most tools should leave this unset.
+     */
+    trustedAudiences?: string[];
   };
 
   /** Dynamic registration configuration for LTI 1.3 tool registration */

--- a/packages/core/src/ltiTool.ts
+++ b/packages/core/src/ltiTool.ts
@@ -73,6 +73,7 @@ import { getValidLaunchConfig } from './utils/launchConfigValidation.js';
 export class LTITool {
   /** Cache for JWKS remote key sets to improve performance */
   private jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+  private verifiedLaunchClientIds = new WeakMap<LTI13JwtPayload, string>();
   private logger: Logger;
   private tokenService: TokenService;
   private agsService: AGSService;
@@ -204,35 +205,44 @@ export class LTITool {
         throw new Error('No issuer in token');
       }
 
-      // 2. get the launchConfig so we can get the remote JWKS from our data store
+      const deploymentId = getDeploymentId(unverified);
+
+      // 2. Verify our state JWT before binding this launch to a client configuration.
+      const stateData = await this.verifyLaunchState(validatedParams.state);
+      if (stateData.iss !== unverified.iss) {
+        throw new Error('Issuer mismatch');
+      }
+
+      // 3. Get the launchConfig so we can get the remote JWKS from our data store.
       const launchConfig = await getValidLaunchConfig(
         this.config.storage,
         unverified.iss,
-        unverified.aud as string,
-        unverified['https://purl.imsglobal.org/spec/lti/claim/deployment_id'] as string,
+        stateData.clientId,
+        deploymentId,
       );
 
-      // 3. Verify LMS JWT
+      // 4. Verify LMS JWT
       const payload = await this.verifyLaunchJwtWithCachedJwks(
         validatedParams.idToken,
         launchConfig.jwksUrl,
-      );
-
-      // 4. Verify our state JWT
-      const { payload: stateData } = await jwtVerify(
-        validatedParams.state,
-        this.config.stateSecret,
+        launchConfig.clientId,
       );
 
       // 5. Parse and validate LMS JWT
       const validated = LTI13JwtPayloadSchema.parse(payload);
 
-      // 6. Verify client id matches (audience claim)
-      if (validated.aud !== launchConfig.clientId) {
+      // 6. Verify client id is listed in the audience claim
+      if (!audienceIncludesClientId(validated.aud, launchConfig.clientId)) {
         throw new Error(
-          `Invalid client_id: expected ${launchConfig.clientId}, got ${validated.aud}`,
+          `Invalid client_id: expected ${launchConfig.clientId}, got ${formatAudience(validated.aud)}`,
         );
       }
+      validateTrustedAudiences(
+        validated.aud,
+        launchConfig.clientId,
+        this.config.security?.trustedAudiences,
+      );
+      this.verifiedLaunchClientIds.set(validated, launchConfig.clientId);
 
       // 7. Verify nonce matches
       if (stateData.nonce !== validated.nonce) {
@@ -260,14 +270,29 @@ export class LTITool {
     return jwks;
   }
 
+  private async verifyLaunchState(
+    state: string,
+  ): Promise<{ clientId: string; iss: string; nonce: unknown }> {
+    const { payload } = await jwtVerify(state, this.config.stateSecret);
+    if (typeof payload.client_id !== 'string') {
+      throw new Error('No client_id in state');
+    }
+    if (typeof payload.iss !== 'string') {
+      throw new Error('No issuer in state');
+    }
+
+    return { clientId: payload.client_id, iss: payload.iss, nonce: payload.nonce };
+  }
+
   private async verifyLaunchJwtWithCachedJwks(
     idToken: string,
     jwksUrl: string,
+    audience: string,
   ): Promise<LTI13JwtPayload> {
     const jwks = this.getOrCreateJwks(jwksUrl);
 
     try {
-      const { payload } = await jwtVerify(idToken, jwks);
+      const { payload } = await jwtVerify(idToken, jwks, { audience });
       return payload as LTI13JwtPayload;
     } catch (error) {
       if ((error as { code?: string }).code !== 'ERR_JWKS_NO_MATCHING_KEY') {
@@ -277,7 +302,7 @@ export class LTITool {
       // Key rotation fallback: evict cached JWKS and retry verification once.
       this.jwksCache.delete(jwksUrl);
       const refreshedJwks = this.getOrCreateJwks(jwksUrl);
-      const { payload } = await jwtVerify(idToken, refreshedJwks);
+      const { payload } = await jwtVerify(idToken, refreshedJwks, { audience });
       return payload as LTI13JwtPayload;
     }
   }
@@ -309,11 +334,17 @@ export class LTITool {
    * Creates and stores a new LTI session from validated JWT payload.
    *
    * @param lti13JwtPayload - Validated LTI 1.3 JWT payload from successful launch
+   * @param clientId - Verified tool client ID when the JWT has multiple audiences. Required if the payload was not returned directly from verifyLaunch on this LTITool instance.
    * @returns Created session object with user, context, and service information
    */
-  async createSession(lti13JwtPayload: LTI13JwtPayload): Promise<LTISession> {
+  async createSession(
+    lti13JwtPayload: LTI13JwtPayload,
+    clientId?: string,
+  ): Promise<LTISession> {
     try {
-      const session = createSession(lti13JwtPayload);
+      const session = createSession(lti13JwtPayload, {
+        clientId: clientId ?? this.verifiedLaunchClientIds.get(lti13JwtPayload),
+      });
       await this.config.storage.addSession(session);
       return session;
     } catch (error) {
@@ -949,6 +980,44 @@ export class LTITool {
       );
     }
   }
+}
+
+function audienceIncludesClientId(
+  audience: LTI13JwtPayload['aud'],
+  clientId: string,
+): boolean {
+  return Array.isArray(audience) ? audience.includes(clientId) : audience === clientId;
+}
+
+function validateTrustedAudiences(
+  audience: LTI13JwtPayload['aud'],
+  clientId: string,
+  trustedAudiences: string[] = [],
+): void {
+  if (!Array.isArray(audience)) return;
+
+  const trusted = new Set([clientId, ...trustedAudiences]);
+  const untrustedAudiences = [...new Set(audience)].filter(
+    (candidate) => !trusted.has(candidate),
+  );
+
+  if (untrustedAudiences.length > 0) {
+    throw new Error(`Untrusted audience(s): ${untrustedAudiences.join(', ')}`);
+  }
+}
+
+function formatAudience(audience: LTI13JwtPayload['aud']): string {
+  return Array.isArray(audience) ? JSON.stringify(audience) : audience;
+}
+
+function getDeploymentId(payload: Record<string, unknown>): string {
+  const deploymentId = payload['https://purl.imsglobal.org/spec/lti/claim/deployment_id'];
+  // The OIDC login parameter is optional, but the signed LTI message claim is required.
+  if (typeof deploymentId !== 'string') {
+    throw new Error('No deployment_id in token');
+  }
+
+  return deploymentId;
 }
 
 /**

--- a/packages/core/src/services/session.service.ts
+++ b/packages/core/src/services/session.service.ts
@@ -14,10 +14,14 @@ const ROLE_MAPPINGS: Record<string, string> = {
  * Extracts user information, context data, and available services into a structured session.
  *
  * @param lti13JwtPayload - Validated LTI 1.3 JWT payload from successful launch
+ * @param options.clientId - Verified tool client ID when the JWT has multiple audiences
  * @returns Complete LTI session object with user, context, and service information
  */
 // oxlint-disable-next-line max-lines-per-function complexity -- flat data mapping
-export function createSession(lti13JwtPayload: LTI13JwtPayload): LTISession {
+export function createSession(
+  lti13JwtPayload: LTI13JwtPayload,
+  options: { clientId?: string } = {},
+): LTISession {
   const roles = lti13JwtPayload['https://purl.imsglobal.org/spec/lti/claim/roles'] || [];
   const context = lti13JwtPayload['https://purl.imsglobal.org/spec/lti/claim/context'];
   const platform =
@@ -89,9 +93,7 @@ export function createSession(lti13JwtPayload: LTI13JwtPayload): LTISession {
     },
     platform: {
       issuer: lti13JwtPayload.iss,
-      clientId: Array.isArray(lti13JwtPayload.aud)
-        ? lti13JwtPayload.aud[0]
-        : lti13JwtPayload.aud,
+      clientId: getSessionClientId(lti13JwtPayload.aud, options.clientId),
       deploymentId:
         lti13JwtPayload['https://purl.imsglobal.org/spec/lti/claim/deployment_id'],
       name: platform?.name || lti13JwtPayload.iss,
@@ -127,6 +129,20 @@ function simplifyRoles(roles: string[]): string[] {
     }
   }
   return [...simplified];
+}
+
+function getSessionClientId(
+  audience: LTI13JwtPayload['aud'],
+  verifiedClientId?: string,
+): string {
+  if (verifiedClientId) return verifiedClientId;
+  if (typeof audience === 'string') return audience;
+  if (audience.length === 1) return audience[0];
+  if (audience.length === 0) {
+    throw new Error('Cannot determine session client_id from empty audience');
+  }
+
+  throw new Error('Cannot determine session client_id from multiple audiences');
 }
 
 function hasRole(roles: string[], pattern: string): boolean {

--- a/packages/core/test/lti-flows.integration.test.ts
+++ b/packages/core/test/lti-flows.integration.test.ts
@@ -213,15 +213,27 @@ describe('LTI Integration Tests', () => {
         code: 'ERR_JWKS_NO_MATCHING_KEY',
       });
       vi.mocked(jwtVerify)
+        .mockResolvedValueOnce({
+          payload: {
+            nonce: 'test-nonce',
+            iss: 'https://platform.example.com',
+            client_id: 'client123',
+          },
+        } as any)
         .mockRejectedValueOnce(kidMissError as any)
-        .mockResolvedValueOnce({ payload: ltiPayload } as any)
-        .mockResolvedValueOnce({ payload: { nonce: 'test-nonce' } } as any);
+        .mockResolvedValueOnce({ payload: ltiPayload } as any);
 
       const validated = await ltiTool.verifyLaunch(idToken, 'state-token');
 
       expect(validated).toEqual(ltiPayload);
       expect(createRemoteJWKSet).toHaveBeenCalledTimes(2);
       expect(jwtVerify).toHaveBeenCalledTimes(3);
+      expect(jwtVerify).toHaveBeenNthCalledWith(2, idToken, staleJwks, {
+        audience: 'client123',
+      });
+      expect(jwtVerify).toHaveBeenNthCalledWith(3, idToken, freshJwks, {
+        audience: 'client123',
+      });
       expect(mockStorage.validateNonce).toHaveBeenCalledWith('test-nonce');
     });
 
@@ -276,6 +288,272 @@ describe('LTI Integration Tests', () => {
       expect(session.isInstructor).toBe(false);
       expect(session.context.label).toBe('CS101');
       expect(session.resourceLink?.title).toBe('Lab 1');
+    });
+
+    it('successfully verifies LTI launch JWT with array audience', async () => {
+      const ltiPayload = createMockLTIPayload({
+        aud: ['client123'],
+        nonce: 'test-nonce',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      const validatedPayload = await ltiTool.verifyLaunch(jwt, stateJwt);
+
+      expect(validatedPayload.aud).toEqual(['client123']);
+      expect(mockStorage.getLaunchConfig).toHaveBeenCalledWith(
+        'https://platform.example.com',
+        'client123',
+        'deployment1',
+      );
+    });
+
+    it('binds launch config and session client ID to state when aud order differs', async () => {
+      ltiTool = new LTITool({
+        keyPair,
+        stateSecret,
+        storage: mockStorage,
+        security: {
+          keyId: 'test-key',
+          stateExpirationSeconds: 300,
+          nonceExpirationSeconds: 300,
+          trustedAudiences: ['other-client'],
+        },
+      });
+
+      vi.mocked(mockStorage.getLaunchConfig).mockImplementation(
+        (iss, clientId, deploymentId) =>
+          Promise.resolve({
+            iss,
+            clientId,
+            deploymentId,
+            authUrl: 'https://platform.example.com/auth',
+            tokenUrl: 'https://platform.example.com/token',
+            jwksUrl: 'https://platform.example.com/.well-known/jwks',
+          }),
+      );
+
+      const ltiPayload = createMockLTIPayload({
+        aud: ['other-client', 'client123'],
+        nonce: 'test-nonce',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      const validatedPayload = await ltiTool.verifyLaunch(jwt, stateJwt);
+      const session = await ltiTool.createSession(validatedPayload);
+
+      expect(validatedPayload.aud).toEqual(['other-client', 'client123']);
+      expect(session.platform.clientId).toBe('client123');
+      expect(mockStorage.getLaunchConfig).toHaveBeenCalledTimes(1);
+      expect(mockStorage.getLaunchConfig).toHaveBeenCalledWith(
+        'https://platform.example.com',
+        'client123',
+        'deployment1',
+      );
+    });
+
+    it('rejects LTI launch JWT with untrusted additional audience', async () => {
+      const ltiPayload = createMockLTIPayload({
+        aud: ['client123', 'other-client'],
+        nonce: 'test-nonce',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      await expect(ltiTool.verifyLaunch(jwt, stateJwt)).rejects.toThrow(
+        'Untrusted audience(s): other-client',
+      );
+    });
+
+    it('rejects LTI launch JWT when state client_id is not in audience', async () => {
+      const ltiPayload = createMockLTIPayload({
+        aud: ['other-client'],
+        nonce: 'test-nonce',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      await expect(ltiTool.verifyLaunch(jwt, stateJwt)).rejects.toThrow();
+    });
+
+    it('rejects LTI launch JWT when state issuer differs from token issuer', async () => {
+      const ltiPayload = createMockLTIPayload({
+        nonce: 'test-nonce',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://different-platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      await expect(ltiTool.verifyLaunch(jwt, stateJwt)).rejects.toThrow(
+        'Issuer mismatch',
+      );
+    });
+
+    it('successfully verifies LTI launch JWT with trusted additional audience', async () => {
+      ltiTool = new LTITool({
+        keyPair,
+        stateSecret,
+        storage: mockStorage,
+        security: {
+          keyId: 'test-key',
+          stateExpirationSeconds: 300,
+          nonceExpirationSeconds: 300,
+          trustedAudiences: ['other-client'],
+        },
+      });
+
+      const ltiPayload = createMockLTIPayload({
+        aud: ['client123', 'other-client'],
+        nonce: 'test-nonce',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      const validatedPayload = await ltiTool.verifyLaunch(jwt, stateJwt);
+
+      expect(validatedPayload.aud).toEqual(['client123', 'other-client']);
+    });
+
+    it('rejects LTI launch JWT with empty audience array', async () => {
+      const ltiPayload = createMockLTIPayload({
+        aud: [],
+        nonce: 'test-nonce',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      await expect(ltiTool.verifyLaunch(jwt, stateJwt)).rejects.toThrow();
+    });
+
+    it('rejects LTI launch JWT without deployment_id claim', async () => {
+      const ltiPayload = createMockLTIPayload();
+      delete ltiPayload['https://purl.imsglobal.org/spec/lti/claim/deployment_id'];
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      await expect(ltiTool.verifyLaunch(jwt, stateJwt)).rejects.toThrow(
+        'No deployment_id in token',
+      );
     });
 
     it('rejects JWT with invalid signature', async () => {

--- a/packages/core/test/session.service.test.ts
+++ b/packages/core/test/session.service.test.ts
@@ -56,6 +56,36 @@ describe('createSession', () => {
     expect(session.isStudent).toBe(false);
   });
 
+  it('uses verified client ID when JWT audience has multiple values', () => {
+    const payload = createMinimalPayload({
+      aud: ['other-client', 'client123'],
+    });
+
+    const session = createSession(payload, { clientId: 'client123' });
+
+    expect(session.platform.clientId).toBe('client123');
+  });
+
+  it('rejects session creation with ambiguous multiple audiences', () => {
+    const payload = createMinimalPayload({
+      aud: ['other-client', 'client123'],
+    });
+
+    expect(() => createSession(payload)).toThrow(
+      'Cannot determine session client_id from multiple audiences',
+    );
+  });
+
+  it('rejects session creation with empty audience array', () => {
+    const payload = createMinimalPayload({
+      aud: [],
+    });
+
+    expect(() => createSession(payload)).toThrow(
+      'Cannot determine session client_id from empty audience',
+    );
+  });
+
   it('correctly identifies instructor role', () => {
     const payload = createMinimalPayload({
       'https://purl.imsglobal.org/spec/lti/claim/roles': [


### PR DESCRIPTION
LTI 1.3 launch messages are OIDC ID Tokens. The audience claim may be a single string or an array, and the tool's client_id is valid when it is contained in that audience list. The signed LTI message also must carry deployment_id, while the OIDC login parameter is only optional: [spec here](https://www.imsglobal.org/spec/lti/v1p3#tool-deployment).

So the code mod here verifies the signed state JWT before resolving launch configuration then binds lookup to the state client_id, and passes that client_id as the jose audience constraint when verifying the platform ID token. 

Then we preserve the resolved client_id through session creation so multi-audience launches do not record aud[0] as the platform client (need to match the correct audience). Direct session creation now requires an explicit verified client_id for ambiguous multi-audience payloads.

Also added a bunch of tests!