### PR TITLE
Bind LTI launch target to login state

### DIFF
--- a/packages/core/src/ltiTool.ts
+++ b/packages/core/src/ltiTool.ts
@@ -188,6 +188,7 @@ export class LTITool {
    * - State JWT verification to prevent CSRF
    * - Nonce validation to prevent replay attacks
    * - Client ID and deployment ID verification
+   * - Target link URI binding to the value requested during login initiation
    * - LTI 1.3 claim structure validation
    *
    * @param idToken - JWT id_token received from platform after authentication
@@ -244,12 +245,15 @@ export class LTITool {
       );
       this.verifiedLaunchClientIds.set(validated, launchConfig.clientId);
 
-      // 7. Verify nonce matches
+      // 7. Verify the launch target is the same target requested during login.
+      validateTargetLinkUri(validated, stateData.targetLinkUri);
+
+      // 8. Verify nonce matches
       if (stateData.nonce !== validated.nonce) {
         throw new Error('Nonce mismatch');
       }
 
-      // 8. Check nonce hasn't been used before (prevent replay attacks)
+      // 9. Check nonce hasn't been used before (prevent replay attacks)
       const isValidNonce = await this.config.storage.validateNonce(validated.nonce);
       if (!isValidNonce) {
         throw new Error('Nonce has already been used or expired');
@@ -272,7 +276,7 @@ export class LTITool {
 
   private async verifyLaunchState(
     state: string,
-  ): Promise<{ clientId: string; iss: string; nonce: unknown }> {
+  ): Promise<{ clientId: string; iss: string; nonce: string; targetLinkUri: string }> {
     const { payload } = await jwtVerify(state, this.config.stateSecret);
     if (typeof payload.client_id !== 'string') {
       throw new Error('No client_id in state');
@@ -280,8 +284,20 @@ export class LTITool {
     if (typeof payload.iss !== 'string') {
       throw new Error('No issuer in state');
     }
+    if (typeof payload.nonce !== 'string') {
+      throw new Error('No nonce in state');
+    }
+    if (typeof payload.target_link_uri !== 'string') {
+      throw new Error('No target_link_uri in state');
+    }
+    HandleLoginParamsSchema.shape.target_link_uri.parse(payload.target_link_uri);
 
-    return { clientId: payload.client_id, iss: payload.iss, nonce: payload.nonce };
+    return {
+      clientId: payload.client_id,
+      iss: payload.iss,
+      nonce: payload.nonce,
+      targetLinkUri: payload.target_link_uri,
+    };
   }
 
   private async verifyLaunchJwtWithCachedJwks(
@@ -1003,6 +1019,21 @@ function validateTrustedAudiences(
 
   if (untrustedAudiences.length > 0) {
     throw new Error(`Untrusted audience(s): ${untrustedAudiences.join(', ')}`);
+  }
+}
+
+function validateTargetLinkUri(
+  payload: LTI13JwtPayload,
+  expectedTargetLinkUri: string,
+): void {
+  const targetLinkUri =
+    payload['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'];
+  // LTI requires this to be the same value passed during login initiation.
+  // Keep this as an exact string match; URL normalization can change routing semantics.
+  if (targetLinkUri !== expectedTargetLinkUri) {
+    throw new Error(
+      `target_link_uri mismatch: expected ${expectedTargetLinkUri}, got ${targetLinkUri}`,
+    );
   }
 }
 

--- a/packages/core/src/schemas/lti13/claims/coreLtiClaims.schema.ts
+++ b/packages/core/src/schemas/lti13/claims/coreLtiClaims.schema.ts
@@ -7,6 +7,6 @@ export const CoreLtiClaimsSchema = z.object({
   ]),
   'https://purl.imsglobal.org/spec/lti/claim/version': z.literal('1.3.0'),
   'https://purl.imsglobal.org/spec/lti/claim/deployment_id': z.string(),
-  'https://purl.imsglobal.org/spec/lti/claim/target_link_uri': z.string(),
+  'https://purl.imsglobal.org/spec/lti/claim/target_link_uri': z.url(),
   'https://purl.imsglobal.org/spec/lti/claim/roles': z.array(z.string()).optional(),
 });

--- a/packages/core/test/lti-flows.integration.test.ts
+++ b/packages/core/test/lti-flows.integration.test.ts
@@ -218,6 +218,7 @@ describe('LTI Integration Tests', () => {
             nonce: 'test-nonce',
             iss: 'https://platform.example.com',
             client_id: 'client123',
+            target_link_uri: 'https://tool.example.com/content',
           },
         } as any)
         .mockRejectedValueOnce(kidMissError as any)
@@ -462,6 +463,125 @@ describe('LTI Integration Tests', () => {
       await expect(ltiTool.verifyLaunch(jwt, stateJwt)).rejects.toThrow(
         'Issuer mismatch',
       );
+    });
+
+    it('successfully verifies LTI launch JWT when target_link_uri matches state', async () => {
+      const ltiPayload = createMockLTIPayload({
+        nonce: 'test-nonce',
+        'https://purl.imsglobal.org/spec/lti/claim/target_link_uri':
+          'https://tool.example.com/content',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      const validatedPayload = await ltiTool.verifyLaunch(jwt, stateJwt);
+
+      expect(
+        validatedPayload['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'],
+      ).toBe('https://tool.example.com/content');
+      expect(mockStorage.validateNonce).toHaveBeenCalledWith('test-nonce');
+    });
+
+    it('rejects LTI launch JWT when state is missing target_link_uri', async () => {
+      const ltiPayload = createMockLTIPayload({
+        nonce: 'test-nonce',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      await expect(ltiTool.verifyLaunch(jwt, stateJwt)).rejects.toThrow(
+        'No target_link_uri in state',
+      );
+      expect(mockStorage.validateNonce).not.toHaveBeenCalled();
+    });
+
+    it('rejects LTI launch JWT when target_link_uri differs from state', async () => {
+      const ltiPayload = createMockLTIPayload({
+        nonce: 'test-nonce',
+        'https://purl.imsglobal.org/spec/lti/claim/target_link_uri':
+          'https://attacker.example.com/content',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      await expect(ltiTool.verifyLaunch(jwt, stateJwt)).rejects.toThrow(
+        'target_link_uri mismatch',
+      );
+      expect(mockStorage.validateNonce).not.toHaveBeenCalled();
+    });
+
+    it('rejects LTI launch JWT when target_link_uri has non-identical URL formatting', async () => {
+      const ltiPayload = createMockLTIPayload({
+        nonce: 'test-nonce',
+        'https://purl.imsglobal.org/spec/lti/claim/target_link_uri':
+          'https://tool.example.com/content/',
+      });
+
+      const { SignJWT } = await import('jose');
+      const jwt = await new SignJWT(ltiPayload)
+        .setProtectedHeader({ alg: 'RS256', kid: 'platform-key' })
+        .sign(platformKeyPair.privateKey);
+
+      const statePayload = {
+        nonce: 'test-nonce',
+        iss: 'https://platform.example.com',
+        client_id: 'client123',
+        target_link_uri: 'https://tool.example.com/content',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      };
+
+      const stateJwt = await new SignJWT(statePayload)
+        .setProtectedHeader({ alg: 'HS256' })
+        .sign(stateSecret);
+
+      await expect(ltiTool.verifyLaunch(jwt, stateJwt)).rejects.toThrow(
+        'target_link_uri mismatch',
+      );
+      expect(mockStorage.validateNonce).not.toHaveBeenCalled();
     });
 
     it('successfully verifies LTI launch JWT with trusted additional audience', async () => {

--- a/packages/core/test/schemas.test.ts
+++ b/packages/core/test/schemas.test.ts
@@ -229,6 +229,28 @@ describe('Schema Validation Tests', () => {
       expect(() => LTI13JwtPayloadSchema.parse(validPayload)).not.toThrow();
     });
 
+    it('rejects payload with invalid target_link_uri', () => {
+      const invalidPayload = {
+        iss: 'https://platform.example.com',
+        sub: 'user123',
+        aud: 'client123',
+        exp: Math.floor(Date.now() / 1000) + 300,
+        iat: Math.floor(Date.now() / 1000),
+        nonce: 'test-nonce',
+        given_name: 'John',
+        family_name: 'Doe',
+        name: 'John Doe',
+        email: 'john.doe@university.edu',
+        'https://purl.imsglobal.org/spec/lti/claim/message_type':
+          'LtiResourceLinkRequest',
+        'https://purl.imsglobal.org/spec/lti/claim/version': '1.3.0',
+        'https://purl.imsglobal.org/spec/lti/claim/deployment_id': 'deployment1',
+        'https://purl.imsglobal.org/spec/lti/claim/target_link_uri': 'not-a-url',
+      };
+
+      expect(() => LTI13JwtPayloadSchema.parse(invalidPayload)).toThrow();
+    });
+
     it('rejects payload with invalid message type', () => {
       const invalidPayload = {
         iss: 'https://platform.example.com',


### PR DESCRIPTION
LTI platforms include target_link_uri twice in the launch flow: first in the third-party initiated login request and later as a signed LTI claim in the id_token. The launch handler ultimately redirects to the signed claim, so verifyLaunch needs to prove that the signed launch target is the same target the tool accepted during login initiation.

This change stores the parsed target_link_uri from the signed state JWT, validates that state value with the same URL schema used by login initiation, and compares it to the verified id_token claim before nonce consumption and session creation. The comparison is intentionally an exact string match rather than URL normalization because LTI requires the same value and normalization can alter routing semantics or hide platform drift.
