### PR TITLE
Fix nonce issuance storage semantics

### DIFF
--- a/.changeset/fix-issued-nonce-storage.md
+++ b/.changeset/fix-issued-nonce-storage.md
@@ -1,0 +1,16 @@
+---
+'@lti-tool/dynamodb': major
+'@lti-tool/d1': patch
+'@lti-tool/memory': patch
+'@lti-tool/mysql': major
+'@lti-tool/postgresql': major
+'@lti-tool/core': patch
+---
+
+Require nonces to be stored before validation succeeds.
+
+MySQL, PostgreSQL, and DynamoDB now store issued nonces during login and atomically mark existing unexpired nonces as used during launch validation. Unknown, expired, or already-used nonces now fail validation instead of being accepted on first sight.
+
+The obsolete `nonceExpirationSeconds` storage adapter option has been removed from MySQL, PostgreSQL, and DynamoDB configuration types. Nonce expiration is controlled by the core LTI security config and passed to storage as the issued nonce `expiresAt` value.
+
+SQL migrations backfill existing nonce rows as consumed so historical replay-protection records cannot become valid unused issued nonces after upgrade.

--- a/packages/core/src/interfaces/ltiStorage.ts
+++ b/packages/core/src/interfaces/ltiStorage.ts
@@ -122,7 +122,8 @@ export interface LTIStorage {
   // Nonce validation (prevent replay attacks)
 
   /**
-   * Stores a nonce with expiration time for replay attack prevention.
+   * Stores an issued nonce with expiration time for replay attack prevention.
+   * Implementations should treat this as create-only and fail if the nonce already exists.
    *
    * @param nonce - Unique nonce value (typically a UUID)
    * @param expiresAt - When this nonce should be considered expired
@@ -130,10 +131,10 @@ export interface LTIStorage {
   storeNonce(nonce: string, expiresAt: Date): Promise<void>;
 
   /**
-   * Validates a nonce and marks it as used to prevent replay attacks.
+   * Validates a previously stored nonce and marks it as used to prevent replay attacks.
    *
    * @param nonce - Nonce value to validate
-   * @returns true if nonce is valid and unused, false if already used or expired
+   * @returns true if nonce was stored, unexpired, and unused; false if unknown, already used, or expired
    */
   validateNonce(nonce: string): Promise<boolean>;
 

--- a/packages/core/src/ltiTool.ts
+++ b/packages/core/src/ltiTool.ts
@@ -146,6 +146,13 @@ export class LTITool {
     try {
       const validatedParams = HandleLoginParamsSchema.parse(params);
 
+      const launchConfig = await getValidLaunchConfig(
+        this.config.storage,
+        validatedParams.iss,
+        validatedParams.client_id,
+        validatedParams.lti_deployment_id,
+      );
+
       const nonce = crypto.randomUUID();
 
       // Store nonce with expiration for replay attack prevention
@@ -164,13 +171,6 @@ export class LTITool {
       })
         .setProtectedHeader({ alg: 'HS256' })
         .sign(this.config.stateSecret);
-
-      const launchConfig = await getValidLaunchConfig(
-        this.config.storage,
-        validatedParams.iss,
-        validatedParams.client_id,
-        validatedParams.lti_deployment_id,
-      );
 
       return buildAuthUrl(launchConfig, validatedParams, state, nonce);
     } catch (error) {
@@ -252,7 +252,9 @@ export class LTITool {
       // 8. Check nonce hasn't been used before (prevent replay attacks)
       const isValidNonce = await this.config.storage.validateNonce(validated.nonce);
       if (!isValidNonce) {
-        throw new Error('Nonce has already been used or expired');
+        throw new Error(
+          'Nonce was not issued by this tool, has expired, or was already used',
+        );
       }
 
       return validated;

--- a/packages/core/test/lti-flows.integration.test.ts
+++ b/packages/core/test/lti-flows.integration.test.ts
@@ -146,6 +146,26 @@ describe('LTI Integration Tests', () => {
       await expect(ltiTool.handleLogin(loginParams)).rejects.toThrow(
         'No valid launch config found',
       );
+      expect(mockStorage.storeNonce).not.toHaveBeenCalled();
+    });
+
+    it('throws error when nonce storage fails', async () => {
+      vi.mocked(mockStorage.storeNonce).mockRejectedValueOnce(
+        new Error('Nonce already exists'),
+      );
+
+      const loginParams = {
+        client_id: 'client123',
+        iss: 'https://platform.example.com',
+        launchUrl: 'https://tool.example.com/launch',
+        login_hint: 'user123',
+        target_link_uri: 'https://tool.example.com/content',
+        lti_deployment_id: 'deployment1',
+      };
+
+      await expect(ltiTool.handleLogin(loginParams)).rejects.toThrow(
+        'Nonce already exists',
+      );
     });
   });
 
@@ -638,7 +658,7 @@ describe('LTI Integration Tests', () => {
         .sign(stateSecret);
 
       await expect(ltiTool.verifyLaunch(jwt, stateJwt)).rejects.toThrow(
-        'Nonce has already been used or expired',
+        'Nonce was not issued by this tool, has expired, or was already used',
       );
     });
   });

--- a/packages/d1/src/d1Storage.ts
+++ b/packages/d1/src/d1Storage.ts
@@ -268,13 +268,6 @@ export class D1Storage implements LTIStorage {
         expiresAt: expiresAt.toISOString(),
         usedAt: null,
       })
-      .onConflictDoUpdate({
-        target: schema.noncesTable.nonce,
-        set: {
-          expiresAt: expiresAt.toISOString(),
-          usedAt: null,
-        },
-      })
       .run();
   }
 

--- a/packages/d1/test/d1Storage.integration.test.ts
+++ b/packages/d1/test/d1Storage.integration.test.ts
@@ -248,12 +248,41 @@ describe('D1Storage with Miniflare D1', () => {
       await expect(harness.storage('validateNonce', 'nonce-id')).resolves.toBe(false);
     });
 
+    it('rejects duplicate nonce storage', async () => {
+      await harness.storage('storeNonce', 'stored-twice-nonce', futureIso());
+
+      await expect(
+        harness.storage('storeNonce', 'stored-twice-nonce', futureIso()),
+      ).rejects.toThrow();
+    });
+
     it('returns false for expired nonces', async () => {
       await harness.storage('storeNonce', 'expired-nonce', pastIso());
 
       await expect(harness.storage('validateNonce', 'expired-nonce')).resolves.toBe(
         false,
       );
+    });
+
+    it('does not allow storeNonce to reopen a consumed nonce', async () => {
+      await harness.storage('storeNonce', 'reused-nonce', futureIso());
+      await expect(harness.storage('validateNonce', 'reused-nonce')).resolves.toBe(true);
+
+      await expect(
+        harness.storage('storeNonce', 'reused-nonce', futureIso()),
+      ).rejects.toThrow();
+      await expect(harness.storage('validateNonce', 'reused-nonce')).resolves.toBe(false);
+    });
+
+    it('allows only one concurrent validation to consume the nonce', async () => {
+      await harness.storage('storeNonce', 'race-nonce', futureIso());
+
+      const results = await Promise.all([
+        harness.storage('validateNonce', 'race-nonce'),
+        harness.storage('validateNonce', 'race-nonce'),
+      ]);
+
+      expect(results.filter(Boolean)).toHaveLength(1);
     });
   });
 

--- a/packages/dynamodb/README.md
+++ b/packages/dynamodb/README.md
@@ -75,11 +75,13 @@ Stores LMS client and deployment configurations.
 
 Stores sessions and nonces with automatic TTL cleanup.
 
-| Attribute | Type   | Description                    |
-| --------- | ------ | ------------------------------ |
-| `pk`      | String | `S#<sessionId>` or `N#<nonce>` |
-| `sk`      | String | Same as pk                     |
-| `ttl`     | Number | TTL for auto cleanup           |
+| Attribute   | Type   | Description                               |
+| ----------- | ------ | ----------------------------------------- |
+| `pk`        | String | `S#<sessionId>` or `N#<nonce>`            |
+| `sk`        | String | Same as pk                                |
+| `expiresAt` | String | Expiration timestamp for nonce validation |
+| `usedAt`    | String | Present after nonce consumption           |
+| `ttl`       | Number | TTL for auto cleanup                      |
 
 ### Launch Config Table (`lti-tool-launch-config`)
 

--- a/packages/dynamodb/src/dynamoDbStorage.ts
+++ b/packages/dynamodb/src/dynamoDbStorage.ts
@@ -9,6 +9,8 @@ import {
   PutItemCommand,
   type PutItemCommandOutput,
   QueryCommand,
+  UpdateItemCommand,
+  type UpdateItemCommandOutput,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import type {
@@ -45,7 +47,6 @@ export class DynamoDbStorage implements LTIStorage {
   private dataPlaneTable: string;
   private launchConfigTable: string;
   private ddbClient: DynamoDBClient;
-  private nonceExpirationSeconds: number;
 
   /**
    * Creates a new DynamoDB storage instance.
@@ -64,7 +65,6 @@ export class DynamoDbStorage implements LTIStorage {
     this.controlPlaneTable = config.controlPlaneTable;
     this.dataPlaneTable = config.dataPlaneTable;
     this.launchConfigTable = config.launchConfigTable;
-    this.nonceExpirationSeconds = config.nonceExpirationSeconds ?? 600;
     this.ddbClient = new DynamoDBClient();
   }
 
@@ -426,41 +426,58 @@ export class DynamoDbStorage implements LTIStorage {
     this.logger.debug({ clientId, deploymentId }, 'deployment deleted');
   }
 
-  // oxlint-disable-next-line no-unused-vars require-await
   async storeNonce(nonce: string, expiresAt: Date): Promise<void> {
-    // Noop - the real work happens in validateNonce with conditional put
-    this.logger.trace({ nonce, expiresAt }, 'nonce will be validated on use');
+    this.logger.debug({ nonce, expiresAt }, 'storing nonce');
+
+    const ttl = Math.floor(expiresAt.getTime() / 1000);
+    const result = await this.ddbClient.send(
+      new PutItemCommand({
+        TableName: this.dataPlaneTable,
+        Item: marshall({
+          pk: this.createNonceKey(nonce),
+          sk: this.createNonceKey(nonce),
+          nonce,
+          expiresAt: expiresAt.toISOString(),
+          ttl,
+        }),
+        ConditionExpression: 'attribute_not_exists(pk)',
+        ReturnConsumedCapacity: 'TOTAL',
+      }),
+    );
+    this.logDynamoDbResult(result, 'store nonce');
   }
 
   async validateNonce(nonce: string): Promise<boolean> {
     this.logger.debug({ nonce }, 'validating nonce');
 
-    const expiresAt = new Date(Date.now() + this.nonceExpirationSeconds * 1000);
-    const ttl = Math.floor(expiresAt.getTime() / 1000);
+    const now = new Date().toISOString();
 
     try {
       const result = await this.ddbClient.send(
-        new PutItemCommand({
+        new UpdateItemCommand({
           TableName: this.dataPlaneTable,
-          Item: marshall({
+          Key: marshall({
             pk: this.createNonceKey(nonce),
             sk: this.createNonceKey(nonce),
-            nonce,
-            expiresAt: expiresAt.toISOString(),
-            ttl,
           }),
-          ConditionExpression: 'attribute_not_exists(pk)', // Only succeed if nonce doesn't exist
+          UpdateExpression: 'SET usedAt = :usedAt',
+          ConditionExpression:
+            'attribute_exists(pk) AND attribute_not_exists(usedAt) AND expiresAt > :now',
+          ExpressionAttributeValues: marshall({
+            ':usedAt': now,
+            ':now': now,
+          }),
           ReturnConsumedCapacity: 'TOTAL',
         }),
       );
       this.logDynamoDbResult(result, 'validate nonce');
-      return true; // Success = nonce was valid
+      return true;
     } catch (error) {
       if (error instanceof ConditionalCheckFailedException) {
-        this.logger.warn({ nonce }, 'nonce already used - replay attack detected');
-        return false; // Nonce already exists = replay attack
+        this.logger.warn({ nonce }, 'nonce not found, expired, or already used');
+        return false;
       }
-      throw error; // Re-throw other errors
+      throw error;
     }
   }
 
@@ -786,7 +803,11 @@ export class DynamoDbStorage implements LTIStorage {
    * Logs DynamoDB operation result and consumed capacity.
    */
   private logDynamoDbResult(
-    result: GetItemCommandOutput | PutItemCommandOutput | DeleteItemCommandOutput,
+    result:
+      | DeleteItemCommandOutput
+      | GetItemCommandOutput
+      | PutItemCommandOutput
+      | UpdateItemCommandOutput,
     operation: string,
   ): void {
     this.logger.debug({ result }, `${operation} result`);

--- a/packages/dynamodb/src/interfaces/dynamoDbStorageConfig.ts
+++ b/packages/dynamodb/src/interfaces/dynamoDbStorageConfig.ts
@@ -5,6 +5,4 @@ export interface DynamoDbStorageConfig {
   controlPlaneTable: string;
   dataPlaneTable: string;
   launchConfigTable: string;
-  /** Nonce expiration time in seconds (defaults to 600) */
-  nonceExpirationSeconds?: number;
 }

--- a/packages/dynamodb/test/dynamoDbStorage.test.ts
+++ b/packages/dynamodb/test/dynamoDbStorage.test.ts
@@ -2,6 +2,8 @@
 import {
   ConditionalCheckFailedException,
   DynamoDBClient,
+  PutItemCommand,
+  UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
 import type { LTIClient, LTISession } from '@lti-tool/core';
@@ -168,8 +170,36 @@ describe('DynamoDbStorage', () => {
     });
   });
 
-  describe('validateNonce', () => {
-    it('returns false for existing nonce (replay attack)', async () => {
+  describe('nonce validation', () => {
+    it('stores nonce with TTL', async () => {
+      mockSend.mockResolvedValue({ $metadata: { httpStatusCode: 200 } });
+
+      const expiresAt = new Date('2030-01-01T00:00:00.000Z');
+
+      await storage.storeNonce('new-nonce', expiresAt);
+
+      expect(mockSend).toHaveBeenCalledOnce();
+      expect(PutItemCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          TableName: 'dataPlane',
+          ConditionExpression: 'attribute_not_exists(pk)',
+        }),
+      );
+    });
+
+    it('propagates duplicate nonce storage failures', async () => {
+      const conditionalError = new ConditionalCheckFailedException({
+        message: 'The conditional request failed',
+        $metadata: {},
+      });
+      mockSend.mockRejectedValue(conditionalError);
+
+      await expect(
+        storage.storeNonce('stored-twice-nonce', new Date(Date.now() + 60_000)),
+      ).rejects.toBe(conditionalError);
+    });
+
+    it('returns false when nonce is not found, expired, or already used', async () => {
       const conditionalError = new ConditionalCheckFailedException({
         message: 'The conditional request failed',
         $metadata: {},
@@ -182,15 +212,38 @@ describe('DynamoDbStorage', () => {
       expect(result).toBe(false);
     });
 
-    it('returns true and stores new nonce', async () => {
-      mockSend
-        .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 }, Item: undefined })
-        .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } });
+    it('returns true and marks a stored nonce used', async () => {
+      mockSend.mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } });
 
-      const result = await storage.validateNonce('new-nonce');
+      const result = await storage.validateNonce('stored-nonce');
 
       expect(result).toBe(true);
-      expect(mockSend).toHaveBeenCalledTimes(1); // single conditional input
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(UpdateItemCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          TableName: 'dataPlane',
+          UpdateExpression: 'SET usedAt = :usedAt',
+          ConditionExpression:
+            'attribute_exists(pk) AND attribute_not_exists(usedAt) AND expiresAt > :now',
+        }),
+      );
+    });
+
+    it('allows only one concurrent validation to consume the nonce', async () => {
+      const conditionalError = new ConditionalCheckFailedException({
+        message: 'The conditional request failed',
+        $metadata: {},
+      });
+      mockSend
+        .mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } })
+        .mockRejectedValueOnce(conditionalError);
+
+      const results = await Promise.all([
+        storage.validateNonce('race-nonce'),
+        storage.validateNonce('race-nonce'),
+      ]);
+
+      expect(results.filter(Boolean)).toHaveLength(1);
     });
   });
 

--- a/packages/memory/src/memoryStorage.ts
+++ b/packages/memory/src/memoryStorage.ts
@@ -37,7 +37,7 @@ export class MemoryStorage implements LTIStorage {
   private clientLookup = new Map<string, string>(); // issuer#clientId -> internalClientId
 
   private sessions = new Map<string, LTISession>();
-  private nonces = new Map<string, Date>(); // nonce -> expiration date
+  private nonces = new Map<string, { expiresAt: Date; usedAt?: Date }>();
   private registrationSessions = new Map<string, LTIDynamicRegistrationSession>();
   private logger: Logger;
 
@@ -168,27 +168,34 @@ export class MemoryStorage implements LTIStorage {
 
   // oxlint-disable-next-line require-await
   async storeNonce(nonce: string, expiresAt: Date): Promise<void> {
-    this.nonces.set(nonce, expiresAt);
+    if (this.nonces.has(nonce)) {
+      throw new Error('Nonce already exists');
+    }
+
+    this.nonces.set(nonce, { expiresAt });
     this.logger.debug({ nonce, expiresAt }, 'nonce stored with expiration');
   }
 
   // oxlint-disable-next-line require-await
   async validateNonce(nonce: string): Promise<boolean> {
-    const expiresAt = this.nonces.get(nonce);
+    const nonceRecord = this.nonces.get(nonce);
 
-    if (!expiresAt) {
+    if (!nonceRecord) {
       this.logger.warn({ nonce }, 'nonce not found - invalid nonce');
       return false;
     }
 
-    if (expiresAt < new Date()) {
-      this.logger.warn({ nonce, expiresAt }, 'nonce expired');
-      this.nonces.delete(nonce); // Clean up expired nonce
+    if (nonceRecord.usedAt) {
+      this.logger.warn({ nonce }, 'nonce already used');
       return false;
     }
 
-    // Mark as used by deleting it (one-time use)
-    this.nonces.delete(nonce);
+    if (nonceRecord.expiresAt < new Date()) {
+      this.logger.warn({ nonce, expiresAt: nonceRecord.expiresAt }, 'nonce expired');
+      return false;
+    }
+
+    nonceRecord.usedAt = new Date();
     this.logger.debug({ nonce }, 'nonce validated and consumed');
     return true;
   }

--- a/packages/memory/test/memoryStorage.test.ts
+++ b/packages/memory/test/memoryStorage.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { MemoryStorage } from '../src/memoryStorage.js';
+
+describe('MemoryStorage - Nonce Validation', () => {
+  it('rejects a nonce that was never stored', async () => {
+    const storage = new MemoryStorage();
+
+    await expect(storage.validateNonce('unknown-nonce')).resolves.toBe(false);
+  });
+
+  it('validates a stored nonce once', async () => {
+    const storage = new MemoryStorage();
+    await storage.storeNonce('nonce-id', new Date(Date.now() + 60_000));
+
+    await expect(storage.validateNonce('nonce-id')).resolves.toBe(true);
+    await expect(storage.validateNonce('nonce-id')).resolves.toBe(false);
+  });
+
+  it('rejects duplicate nonce storage', async () => {
+    const storage = new MemoryStorage();
+    await storage.storeNonce('dup-nonce', new Date(Date.now() + 60_000));
+
+    await expect(
+      storage.storeNonce('dup-nonce', new Date(Date.now() + 60_000)),
+    ).rejects.toThrow('Nonce already exists');
+  });
+
+  it('does not allow storeNonce to reopen a consumed nonce', async () => {
+    const storage = new MemoryStorage();
+    await storage.storeNonce('reused-nonce', new Date(Date.now() + 60_000));
+    await expect(storage.validateNonce('reused-nonce')).resolves.toBe(true);
+
+    await expect(
+      storage.storeNonce('reused-nonce', new Date(Date.now() + 60_000)),
+    ).rejects.toThrow('Nonce already exists');
+    await expect(storage.validateNonce('reused-nonce')).resolves.toBe(false);
+  });
+
+  it('allows only one concurrent validation to consume the nonce', async () => {
+    const storage = new MemoryStorage();
+    await storage.storeNonce('race-nonce', new Date(Date.now() + 60_000));
+
+    const results = await Promise.all([
+      storage.validateNonce('race-nonce'),
+      storage.validateNonce('race-nonce'),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+});

--- a/packages/mysql/README.md
+++ b/packages/mysql/README.md
@@ -66,7 +66,6 @@ npx drizzle-kit migrate
 - **poolOptions** (optional): mysql2 pool configuration
   - `connectionLimit`: Max connections (auto: 1 for serverless, 10 for servers)
   - `queueLimit`: Max queued requests (default: 0 = unlimited)
-- **nonceExpirationSeconds** (optional): Nonce TTL in seconds (default: 600)
 
 - **logger** (optional): Pino logger for debugging
 
@@ -82,11 +81,11 @@ The adapter uses these tables:
   Indexed: `expiresAt`
 - **nonces**: One-time use nonces
   Primary key: `nonce`
-  Indexed: `expiresAt`
+  Consumed with `usedAt`
 - **registrationSessions**: Dynamic registration sessions
   Indexed: `expiresAt`
 
-All tables use UUIDs for primary keys and include indexes for performance.
+Tables use UUIDs for primary keys and include indexes where lookup and cleanup paths need them.
 
 ### clients
 
@@ -134,10 +133,11 @@ All tables use UUIDs for primary keys and include indexes for performance.
 
 ### nonces
 
-| Column      | Type         | Constraints           | Description                |
-| ----------- | ------------ | --------------------- | -------------------------- |
-| `nonce`     | VARCHAR(255) | PRIMARY KEY, NOT NULL | One-time use nonce value   |
-| `expiresAt` | DATETIME     | NOT NULL              | Nonce expiration timestamp |
+| Column      | Type         | Constraints           | Description                 |
+| ----------- | ------------ | --------------------- | --------------------------- |
+| `nonce`     | VARCHAR(255) | PRIMARY KEY, NOT NULL | One-time use nonce value    |
+| `expiresAt` | DATETIME     | NOT NULL              | Nonce expiration timestamp  |
+| `usedAt`    | DATETIME     | NULL                  | When the nonce was consumed |
 
 ### registrationSessions
 

--- a/packages/mysql/drizzle/0001_issued_nonce_used_at.sql
+++ b/packages/mysql/drizzle/0001_issued_nonce_used_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `nonces` ADD `usedAt` datetime;--> statement-breakpoint
+UPDATE `nonces` SET `usedAt` = NOW() WHERE `usedAt` IS NULL;

--- a/packages/mysql/drizzle/meta/0001_snapshot.json
+++ b/packages/mysql/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,284 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "897c018a-4c0c-4002-b40a-18614f00d471",
+  "prevId": "6363e9d8-669d-482e-9410-3fa45d7034ea",
+  "tables": {
+    "clients": {
+      "name": "clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iss": {
+          "name": "iss",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authUrl": {
+          "name": "authUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tokenUrl": {
+          "name": "tokenUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "jwksUrl": {
+          "name": "jwksUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "issuer_client_idx": {
+          "name": "issuer_client_idx",
+          "columns": ["clientId", "iss"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "clients_id": {
+          "name": "clients_id",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {
+        "iss_client_id_unique": {
+          "name": "iss_client_id_unique",
+          "columns": ["iss", "clientId"]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "deployments": {
+      "name": "deployments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deploymentId": {
+          "name": "deploymentId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "deployment_id_idx": {
+          "name": "deployment_id_idx",
+          "columns": ["deploymentId"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "deployments_clientId_clients_id_fk": {
+          "name": "deployments_clientId_clients_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "clients",
+          "columnsFrom": ["clientId"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "deployments_id": {
+          "name": "deployments_id",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {
+        "client_deployment_unique": {
+          "name": "client_deployment_unique",
+          "columns": ["clientId", "deploymentId"]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "nonces": {
+      "name": "nonces",
+      "columns": {
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nonces_nonce": {
+          "name": "nonces_nonce",
+          "columns": ["nonce"]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "registrationSessions": {
+      "name": "registrationSessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "expires_at_idx": {
+          "name": "expires_at_idx",
+          "columns": ["expiresAt"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "registrationSessions_id": {
+          "name": "registrationSessions_id",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "expires_at_idx": {
+          "name": "expires_at_idx",
+          "columns": ["expiresAt"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sessions_id": {
+          "name": "sessions_id",
+          "columns": ["id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/packages/mysql/drizzle/meta/_journal.json
+++ b/packages/mysql/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1767550065237,
       "tag": "0000_careless_vermin",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1780594470024,
+      "tag": "0001_issued_nonce_used_at",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/mysql/src/db/schema/nonces.schema.ts
+++ b/packages/mysql/src/db/schema/nonces.schema.ts
@@ -3,4 +3,5 @@ import { datetime, mysqlTable, varchar } from 'drizzle-orm/mysql-core';
 export const noncesTable = mysqlTable('nonces', {
   nonce: varchar({ length: 255 }).primaryKey(),
   expiresAt: datetime().notNull(),
+  usedAt: datetime(),
 });

--- a/packages/mysql/src/interfaces/mySqlStorageConfig.ts
+++ b/packages/mysql/src/interfaces/mySqlStorageConfig.ts
@@ -24,8 +24,4 @@ export interface MySqlStorageConfig {
     connectionLimit?: number;
     queueLimit?: number;
   };
-  /**
-   * Nonce expiration time in seconds (defaults to 600 = 10 minutes)
-   */
-  nonceExpirationSeconds?: number;
 }

--- a/packages/mysql/src/mysqlStorage.ts
+++ b/packages/mysql/src/mysqlStorage.ts
@@ -7,7 +7,7 @@ import {
   type LTISession,
   type LTIStorage,
 } from '@lti-tool/core';
-import { and, eq, gt, lt } from 'drizzle-orm';
+import { and, eq, gt, isNull, lt } from 'drizzle-orm';
 import { drizzle, type MySql2Database } from 'drizzle-orm/mysql2';
 import mysql from 'mysql2/promise';
 import type { Logger } from 'pino';
@@ -32,7 +32,6 @@ export class MySqlStorage implements LTIStorage {
   private logger: Logger;
   private db: MySql2Database<typeof schema>;
   private pool: mysql.Pool;
-  private nonceExpirationSeconds: number;
 
   constructor(config: MySqlStorageConfig) {
     this.logger =
@@ -43,8 +42,6 @@ export class MySqlStorage implements LTIStorage {
         warn: () => {},
         error: () => {},
       } as unknown as Logger);
-
-    this.nonceExpirationSeconds = config.nonceExpirationSeconds ?? 600;
 
     // Smart connection limit defaults
     const isServerless = isServerlessEnvironment();
@@ -350,47 +347,35 @@ export class MySqlStorage implements LTIStorage {
     this.logger.debug({ clientId, deploymentId }, 'deployment deleted');
   }
 
-  // oxlint-disable-next-line no-unused-vars require-await
   async storeNonce(nonce: string, expiresAt: Date): Promise<void> {
-    // Noop - the real work happens in validateNonce
-    this.logger.trace({ nonce, expiresAt }, 'nonce will be validated on use');
+    this.logger.debug({ nonce, expiresAt }, 'storing nonce');
+
+    await this.db.insert(schema.noncesTable).values({
+      nonce,
+      expiresAt,
+      usedAt: null,
+    });
   }
 
   async validateNonce(nonce: string): Promise<boolean> {
     this.logger.debug({ nonce }, 'validating nonce');
 
-    // 1. Check if nonce exists and is still valid (not expired)
-    const [existing] = await this.db
-      .select()
-      .from(schema.noncesTable)
+    const result = await this.db
+      .update(schema.noncesTable)
+      .set({ usedAt: new Date() })
       .where(
         and(
           eq(schema.noncesTable.nonce, nonce),
-          gt(schema.noncesTable.expiresAt, new Date()), // expiresAt > NOW()
+          isNull(schema.noncesTable.usedAt),
+          gt(schema.noncesTable.expiresAt, new Date()),
         ),
-      )
-      .limit(1);
+      );
 
-    if (existing) {
-      this.logger.warn({ nonce }, 'nonce already used - replay attack detected');
-      return false; // Nonce exists and hasn't expired = replay attack
+    const wasConsumed = Number(result[0]?.affectedRows ?? 0) === 1;
+    if (!wasConsumed) {
+      this.logger.warn({ nonce }, 'nonce not found, expired, or already used');
     }
-
-    // 2. Try to insert the nonce
-    const expiresAt = new Date(Date.now() + this.nonceExpirationSeconds * 1000);
-
-    try {
-      await this.db.insert(schema.noncesTable).values({ nonce, expiresAt });
-      return true;
-    } catch (error) {
-      // Duplicate key error (race condition - another request inserted same nonce)
-      // MySQL error code for duplicate entry
-      if ((error as { code?: string }).code === 'ER_DUP_ENTRY') {
-        this.logger.warn({ nonce }, 'nonce collision detected - replay attack');
-        return false;
-      }
-      throw error;
-    }
+    return wasConsumed;
   }
 
   async getSession(sessionId: string): Promise<LTISession | undefined> {
@@ -413,7 +398,7 @@ export class MySqlStorage implements LTIStorage {
       .where(
         and(
           eq(schema.sessionsTable.id, sessionId),
-          gt(schema.sessionsTable.expiresAt, new Date()), // Not expired
+          gt(schema.sessionsTable.expiresAt, new Date()),
         ),
       )
       .limit(1);
@@ -528,12 +513,10 @@ export class MySqlStorage implements LTIStorage {
   ): Promise<void> {
     this.logger.debug({ sessionId }, 'setting registration session');
 
-    const expiresAt = new Date(session.expiresAt);
-
     await this.db.insert(schema.registrationSessionsTable).values({
       id: sessionId,
       data: session,
-      expiresAt,
+      expiresAt: new Date(session.expiresAt),
     });
 
     this.logger.debug({ sessionId }, 'registration session stored');

--- a/packages/mysql/test/mysqlStorage.integration.test.ts
+++ b/packages/mysql/test/mysqlStorage.integration.test.ts
@@ -151,15 +151,50 @@ describe('MySqlStorage - Session Operations', () => {
 });
 
 describe('MySqlStorage - Nonce Validation', () => {
-  it('should validate a new nonce', async () => {
+  it('should reject a nonce that was never stored', async () => {
+    const result = await storage.validateNonce('unknown-nonce');
+    expect(result).toBe(false);
+  });
+
+  it('should validate a stored nonce once', async () => {
+    await storage.storeNonce('unique-nonce', new Date(Date.now() + 60_000));
+
     const result = await storage.validateNonce('unique-nonce');
     expect(result).toBe(true);
   });
 
-  it('should reject duplicate nonce', async () => {
+  it('should reject duplicate nonce storage', async () => {
+    await storage.storeNonce('stored-twice-nonce', new Date(Date.now() + 60_000));
+
+    await expect(
+      storage.storeNonce('stored-twice-nonce', new Date(Date.now() + 60_000)),
+    ).rejects.toThrow();
+  });
+
+  it('should reject duplicate nonce validation', async () => {
+    await storage.storeNonce('dup-nonce', new Date(Date.now() + 60_000));
     await storage.validateNonce('dup-nonce');
+
     const result = await storage.validateNonce('dup-nonce');
     expect(result).toBe(false);
+  });
+
+  it('should reject expired stored nonces', async () => {
+    await storage.storeNonce('expired-nonce', new Date(Date.now() - 1000));
+
+    const result = await storage.validateNonce('expired-nonce');
+    expect(result).toBe(false);
+  });
+
+  it('should allow only one concurrent validation to consume the nonce', async () => {
+    await storage.storeNonce('race-nonce', new Date(Date.now() + 60_000));
+
+    const results = await Promise.all([
+      storage.validateNonce('race-nonce'),
+      storage.validateNonce('race-nonce'),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
   });
 });
 

--- a/packages/postgresql/README.md
+++ b/packages/postgresql/README.md
@@ -66,7 +66,6 @@ npx drizzle-kit migrate
 - **poolOptions** (optional): postgres.js connection options
   - `max`: Max connections (auto: 1 for serverless, 10 for servers)
   - `idleTimeout`: Idle timeout in seconds before connection is closed (default: 20)
-- **nonceExpirationSeconds** (optional): Nonce TTL in seconds (default: 600)
 
 - **logger** (optional): Pino logger for debugging
 
@@ -83,6 +82,7 @@ The adapter uses these tables:
 - **nonces**: One-time use nonces
   Primary key: `nonce`
   Indexed: `expiresAt`
+  Consumed with `usedAt`
 - **registration_sessions**: Dynamic registration sessions
   Indexed: `expiresAt`
 
@@ -134,10 +134,11 @@ All tables use native PostgreSQL UUIDs for primary keys and include indexes for 
 
 ### nonces
 
-| Column      | Type                     | Constraints           | Description                |
-| ----------- | ------------------------ | --------------------- | -------------------------- |
-| `nonce`     | VARCHAR(255)             | PRIMARY KEY, NOT NULL | One-time use nonce value   |
-| `expiresAt` | TIMESTAMP WITH TIME ZONE | NOT NULL              | Nonce expiration timestamp |
+| Column      | Type                     | Constraints           | Description                 |
+| ----------- | ------------------------ | --------------------- | --------------------------- |
+| `nonce`     | VARCHAR(255)             | PRIMARY KEY, NOT NULL | One-time use nonce value    |
+| `expiresAt` | TIMESTAMP WITH TIME ZONE | NOT NULL              | Nonce expiration timestamp  |
+| `usedAt`    | TIMESTAMP WITH TIME ZONE | NULL                  | When the nonce was consumed |
 
 ### registration_sessions
 

--- a/packages/postgresql/drizzle/0001_lonely_siren.sql
+++ b/packages/postgresql/drizzle/0001_lonely_siren.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "nonces" ADD COLUMN "used_at" timestamp with time zone;--> statement-breakpoint
+UPDATE "nonces" SET "used_at" = NOW() WHERE "used_at" IS NULL;

--- a/packages/postgresql/drizzle/meta/0001_snapshot.json
+++ b/packages/postgresql/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,336 @@
+{
+  "id": "a1b80f44-b3c0-4583-b85c-53a78752d33a",
+  "prevId": "7e071465-0b94-4f8d-a120-45ddb5575592",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iss": {
+          "name": "iss",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_url": {
+          "name": "auth_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jwks_url": {
+          "name": "jwks_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "issuer_client_idx": {
+          "name": "issuer_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "iss",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "iss_client_id_unique": {
+          "name": "iss_client_id_unique",
+          "columns": [
+            {
+              "expression": "iss",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployments": {
+      "name": "deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "deployment_id_idx": {
+          "name": "deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_deployment_unique": {
+          "name": "client_deployment_unique",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployments_client_id_clients_id_fk": {
+          "name": "deployments_client_id_clients_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nonces": {
+      "name": "nonces",
+      "schema": "",
+      "columns": {
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registration_sessions": {
+      "name": "registration_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "reg_sessions_expires_at_idx": {
+          "name": "reg_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/postgresql/drizzle/meta/_journal.json
+++ b/packages/postgresql/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1770007114581,
       "tag": "0000_black_mentallo",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1780591633275,
+      "tag": "0001_lonely_siren",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/postgresql/src/db/schema/nonces.schema.ts
+++ b/packages/postgresql/src/db/schema/nonces.schema.ts
@@ -3,4 +3,5 @@ import { pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
 export const noncesTable = pgTable('nonces', {
   nonce: varchar('nonce', { length: 255 }).primaryKey(),
   expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+  usedAt: timestamp('used_at', { withTimezone: true }),
 });

--- a/packages/postgresql/src/interfaces/postgresStorageConfig.ts
+++ b/packages/postgresql/src/interfaces/postgresStorageConfig.ts
@@ -28,8 +28,4 @@ export interface PostgresStorageConfig {
      */
     idleTimeout?: number;
   };
-  /**
-   * Nonce expiration time in seconds (defaults to 600 = 10 minutes)
-   */
-  nonceExpirationSeconds?: number;
 }

--- a/packages/postgresql/src/postgresStorage.ts
+++ b/packages/postgresql/src/postgresStorage.ts
@@ -7,7 +7,7 @@ import {
   type LTISession,
   type LTIStorage,
 } from '@lti-tool/core';
-import { and, eq, gt, lt } from 'drizzle-orm';
+import { and, eq, gt, isNull, lt } from 'drizzle-orm';
 import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { Logger } from 'pino';
 import postgres from 'postgres';
@@ -32,7 +32,6 @@ export class PostgresStorage implements LTIStorage {
   private logger: Logger;
   private db: PostgresJsDatabase<typeof schema>;
   private sql: postgres.Sql;
-  private nonceExpirationSeconds: number;
 
   constructor(config: PostgresStorageConfig) {
     this.logger =
@@ -43,8 +42,6 @@ export class PostgresStorage implements LTIStorage {
         warn: () => {},
         error: () => {},
       } as unknown as Logger);
-
-    this.nonceExpirationSeconds = config.nonceExpirationSeconds ?? 600;
 
     // Smart connection limit defaults
     const isServerless = isServerlessEnvironment();
@@ -349,47 +346,37 @@ export class PostgresStorage implements LTIStorage {
     this.logger.debug({ clientId, deploymentId }, 'deployment deleted');
   }
 
-  // oxlint-disable-next-line no-unused-vars require-await
   async storeNonce(nonce: string, expiresAt: Date): Promise<void> {
-    // Noop - the real work happens in validateNonce
-    this.logger.trace({ nonce, expiresAt }, 'nonce will be validated on use');
+    this.logger.debug({ nonce, expiresAt }, 'storing nonce');
+
+    await this.db.insert(schema.noncesTable).values({
+      nonce,
+      expiresAt,
+      usedAt: null,
+    });
   }
 
   async validateNonce(nonce: string): Promise<boolean> {
     this.logger.debug({ nonce }, 'validating nonce');
 
-    // 1. Check if nonce exists and is still valid (not expired)
-    const [existing] = await this.db
-      .select()
-      .from(schema.noncesTable)
+    const [updated] = await this.db
+      .update(schema.noncesTable)
+      .set({ usedAt: new Date() })
       .where(
         and(
           eq(schema.noncesTable.nonce, nonce),
-          gt(schema.noncesTable.expiresAt, new Date()), // expiresAt > NOW()
+          isNull(schema.noncesTable.usedAt),
+          gt(schema.noncesTable.expiresAt, new Date()),
         ),
       )
-      .limit(1);
+      .returning({ nonce: schema.noncesTable.nonce });
 
-    if (existing) {
-      this.logger.warn({ nonce }, 'nonce already used - replay attack detected');
-      return false; // Nonce exists and hasn't expired = replay attack
+    if (!updated) {
+      this.logger.warn({ nonce }, 'nonce not found, expired, or already used');
+      return false;
     }
 
-    // 2. Try to insert the nonce
-    const expiresAt = new Date(Date.now() + this.nonceExpirationSeconds * 1000);
-
-    try {
-      await this.db.insert(schema.noncesTable).values({ nonce, expiresAt });
-      return true;
-    } catch (error) {
-      // Duplicate key error (race condition - another request inserted same nonce)
-      // PostgreSQL error code for unique_violation
-      if ((error as { code?: string }).code === '23505') {
-        this.logger.warn({ nonce }, 'nonce collision detected - replay attack');
-        return false;
-      }
-      throw error;
-    }
+    return true;
   }
 
   async getSession(sessionId: string): Promise<LTISession | undefined> {

--- a/packages/postgresql/test/postgresStorage.integration.test.ts
+++ b/packages/postgresql/test/postgresStorage.integration.test.ts
@@ -153,15 +153,50 @@ describe('PostgresStorage - Session Operations', () => {
 });
 
 describe('PostgresStorage - Nonce Validation', () => {
-  it('should validate a new nonce', async () => {
+  it('should reject a nonce that was never stored', async () => {
+    const result = await storage.validateNonce('unknown-nonce');
+    expect(result).toBe(false);
+  });
+
+  it('should validate a stored nonce once', async () => {
+    await storage.storeNonce('unique-nonce', new Date(Date.now() + 60_000));
+
     const result = await storage.validateNonce('unique-nonce');
     expect(result).toBe(true);
   });
 
-  it('should reject duplicate nonce', async () => {
+  it('should reject duplicate nonce storage', async () => {
+    await storage.storeNonce('stored-twice-nonce', new Date(Date.now() + 60_000));
+
+    await expect(
+      storage.storeNonce('stored-twice-nonce', new Date(Date.now() + 60_000)),
+    ).rejects.toThrow();
+  });
+
+  it('should reject duplicate nonce validation', async () => {
+    await storage.storeNonce('dup-nonce', new Date(Date.now() + 60_000));
     await storage.validateNonce('dup-nonce');
+
     const result = await storage.validateNonce('dup-nonce');
     expect(result).toBe(false);
+  });
+
+  it('should reject expired stored nonces', async () => {
+    await storage.storeNonce('expired-nonce', new Date(Date.now() - 1000));
+
+    const result = await storage.validateNonce('expired-nonce');
+    expect(result).toBe(false);
+  });
+
+  it('should allow only one concurrent validation to consume the nonce', async () => {
+    await storage.storeNonce('race-nonce', new Date(Date.now() + 60_000));
+
+    const results = await Promise.all([
+      storage.validateNonce('race-nonce'),
+      storage.validateNonce('race-nonce'),
+    ]);
+
+    expect(results.filter(Boolean)).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
Require launch nonces to be issued by the tool before validation can succeed. The previous SQL and DynamoDB adapters accepted an unseen nonce on first validation, which meant manually forged state with a fresh nonce could pass storage validation instead of being rejected (as it was never issued).

We should store nonces during login and make launch validation atomically consume an existing unexpired unused nonce. This updates DynamoDB, PostgreSQL, MySQL, D1, and memory storage to share the same create-only storeNonce and consume-once validateNonce contract.

We should remove obsolete storage-level nonceExpirationSeconds options from SQL and DynamoDB configs because nonce TTL is controlled by the core security config and passed to storage as expiresAt. 

Add tests for unknown nonces, duplicate store, single-use validation, expired nonces, and concurrent validation scenario.